### PR TITLE
subscriber custom headers change

### DIFF
--- a/iron_mq.py
+++ b/iron_mq.py
@@ -154,7 +154,7 @@ class Queue:
     # 1) a url string
     # 2) a tuple of (url, headers)
     # 3) a list of url strings or tuples
-    # headers must be in format: {'Example':'Header'}
+    # headers must be in the format: {'Example':'Header'}
     def update(self, subscribers=None, **kwargs):
         url = "queues/%s" % self.name
         body = kwargs


### PR DESCRIPTION
Not sure whether to use a tuple or a dict to specify custom headers (currently using tuples).
('url', {'custom': 'headers'}) vs {'url': 'someurl.com', 'headers': {'custom': 'headers'}}
