### PR TITLE
added correction for readme and setup.py files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ To start using iron_mq_python, you need to sign up and get an OAuth2 token.
 ## Install iron_mq_python
 
 ```sh
-pip install iron-mq
+pip install iron-mq-v3
 ```
 
-or just copy `iron_mq.py` and include it in your script:
+or just copy `iron_mq.py` of v3 and include it in your script:
 
 ```python
 from iron_mq import *
@@ -34,7 +34,7 @@ ironmq = IronMQ(host='mq-aws-us-east-1.iron.io',
                 project_id='500f7b....b0f302e9',
                 token='Et1En7.....0LuW39Q',
                 protocol='https', port=443,
-                api_version=1,
+                api_version=3,
                 config_file=None)
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(
-        name = "iron-mq",
+        name = "iron-mq-v3",
         py_modules = ["iron_mq"],
         install_requires = ["iron_core"],
         version = "0.5",


### PR DESCRIPTION
To install iron_mq_v3 with pip, run following command: pip install iron-mq-v3
