### PR TITLE
2to3 compatibility: urlencode is in urllib in python2 and urllib.parse in python3

### DIFF
--- a/iron_mq.py
+++ b/iron_mq.py
@@ -1,5 +1,9 @@
 import iron_core
-import urllib
+
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlencode
 
 try:
     import json
@@ -328,7 +332,7 @@ class IronMQ(object):
         if prefix is not None:
             options['prefix'] = prefix
 
-        query = urllib.urlencode(options)
+        query = urlencode(options)
         url = 'queues'
         if query != '':
             url = "%s?%s" % (url, query)


### PR DESCRIPTION
I was trying to use the `queues` method in python3, but ran into an error:
```
>>> from iron_mq import *
>>> client = IronMQ()
>>> client.queues()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.4/dist-packages/iron_mq.py", line 331, in queues
    query = urllib.urlencode(options)
AttributeError: 'module' object has no attribute 'urlencode'
```

In python3 the urlencode method has moved to the urllib.parse submodule.  This PR tries first to import from the submodule.  If it doesn't exist -- as in python2 -- it tries importing it from urllib.

Dunno if other iron.io python libraries might have the same issue.